### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jest-unit-tests.yml
+++ b/.github/workflows/jest-unit-tests.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maslindc2/FlockWatch-Scraping/security/code-scanning/2](https://github.com/maslindc2/FlockWatch-Scraping/security/code-scanning/2)

Add an explicit top-level `permissions` block to `.github/workflows/jest-unit-tests.yml` so all jobs in this workflow inherit least-privilege token access.  
For this workflow, the best minimal permission is:

- `contents: read`

This preserves existing functionality (checkout + install + test) while preventing unintended write scopes if repo/org defaults are broader.

Change location:
- File: `.github/workflows/jest-unit-tests.yml`
- Insert directly after the `on:` trigger block (before `jobs:`), or near the top-level keys.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
