### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jest-integration-tests.yml
+++ b/.github/workflows/jest-integration-tests.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   integration_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maslindc2/FlockWatch-Scraping/security/code-scanning/1](https://github.com/maslindc2/FlockWatch-Scraping/security/code-scanning/1)

To fix this without changing workflow behavior, add an explicit `permissions` block at the workflow root so it applies to all jobs (currently there is one). The minimal safe permission here is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI tasks while preventing unnecessary write access by default.

**File to change:** `.github/workflows/jest-integration-tests.yml`  
**Region to change:** near the top-level keys (`name`, `on`, before `jobs`).

No imports, methods, or dependencies are needed; this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
