### PR TITLE
fix: Improved the selection options for the data. 

### DIFF
--- a/src/controllers/scraper.controller.ts
+++ b/src/controllers/scraper.controller.ts
@@ -102,7 +102,7 @@ class ScraperController {
             // Process the mapComparisons CSV
             const flockCasesByState: FlockCasesByState[] =
                 await dataProcessor.processMapComparisonsCSV(mapComparisonCSV);
-            
+
             // Process the last 30 day totals
             const periodSummaries: Last30Days[] =
                 await dataProcessor.processLast30DayTotalsCSVs(

--- a/src/controllers/scraper.controller.ts
+++ b/src/controllers/scraper.controller.ts
@@ -102,7 +102,7 @@ class ScraperController {
             // Process the mapComparisons CSV
             const flockCasesByState: FlockCasesByState[] =
                 await dataProcessor.processMapComparisonsCSV(mapComparisonCSV);
-
+            
             // Process the last 30 day totals
             const periodSummaries: Last30Days[] =
                 await dataProcessor.processLast30DayTotalsCSVs(

--- a/src/modules/scraper/usda-scraping.service.ts
+++ b/src/modules/scraper/usda-scraping.service.ts
@@ -205,13 +205,13 @@ class USDAScrapingService {
             await this.humanDelay();
 
             // Provides us with the birds affected in the last 30 days. We do not need to change the variable or time period, but we do need to select the ExportToCsv option.
-            // This provides us with a clean CSV file for processing the latest infections. 
+            // This provides us with a clean CSV file for processing the latest infections.
             // We then click the Download button and the CSV option to get the download URL.
             await this.page
                 .locator('[role="button"]:has-text("Download Data")')
                 .click();
             await this.humanDelay();
-            
+
             await this.page.getByTitle("ExportToCsv").click();
             await this.humanDelay();
 

--- a/src/modules/scraper/usda-scraping.service.ts
+++ b/src/modules/scraper/usda-scraping.service.ts
@@ -204,12 +204,17 @@ class USDAScrapingService {
             await this.page.goto(this.scrapeURL);
             await this.humanDelay();
 
-            // This is where we normally would select the options for the data we want, however for the ExportToCsv the option is already selected for us.
-            // So we have to click the Download button and the CSV option to get the download URL, but we don't have to select any options beforehand
+            // Provides us with the birds affected in the last 30 days. We do not need to change the variable or time period, but we do need to select the ExportToCsv option.
+            // This provides us with a clean CSV file for processing the latest infections. 
+            // We then click the Download button and the CSV option to get the download URL.
             await this.page
                 .locator('[role="button"]:has-text("Download Data")')
                 .click();
             await this.humanDelay();
+            
+            await this.page.getByTitle("ExportToCsv").click();
+            await this.humanDelay();
+
             await this.page
                 .getByTestId("crosstab-options-dialog-radio-csv-Label")
                 .click();


### PR DESCRIPTION
USDA has added new options for downloads. This broke the scraper on our ExportToCSV step. I originally didn't select the ExportToCSV option as the download tool would default to that option. This step has now been patched by selecting the ExportToCSV option in the download tool.